### PR TITLE
mingw32-unzip: Add mingw version of unzip

### DIFF
--- a/root/packages/mingw32-unzip/unzip-60-1.mgwport
+++ b/root/packages/mingw32-unzip/unzip-60-1.mgwport
@@ -1,0 +1,31 @@
+DESCRIPTION="UnZip is an extraction utility for archives compressed in .zip format (also called \"zipfiles\")."
+HOMEPAGE="http://info-zip.org/"
+
+SRC_URI="ftp://ftp.info-zip.org/pub/infozip/src/${PN}${PV}.tgz"
+SRC_DIR="${PN}${PV}"
+
+PKG_NAMES="${PN} ${PN} ${PN}"
+
+PKG_COMPTYPES="bin doc lic"
+
+PKG_CONTENTS[0]="bin"
+PKG_CONTENTS[1]="share/doc
+                 --exclude share/doc/${PN}/${PV}/LICENSE"
+PKG_CONTENTS[2]="share/doc/${PN}/${PV}/LICENSE"
+
+src_compile() {
+  lndirs
+  cd ${B}
+  make -f win32/Makefile.gcc
+}
+
+src_install() {
+ cd ${B} 
+ dobin unzip.exe
+ dobin funzip.exe
+ dobin unzipsfx.exe
+ 
+ dodoc unzip.txt funzip.txt unzipsfx.txt
+ dodoc INSTALL README BUGS MANUAL ToDo WHERE History.600
+}
+


### PR DESCRIPTION
The available msys version of unzip causes
some tests from t5003-archive-zip.sh from the git
test suite to either hang indefinitly or fail.

I've used 1b38b168aed17937270d29b58ec1fee16df46acb on top of your mingw32-git branch for test execution.

``` sh
GIT_UNZIP="/bin/unzip" prove -v t5003-archive-zip.sh
[....]
DIED. FAILED tests 9-11, 17-19, 21-23, 25
        Failed 10/27 tests, 62.96% okay (less 1 skipped test: 16 okay, 59.26%)
Failed Test          Stat Wstat Total Fail  Failed  List of Failed
-------------------------------------------------------------------------------
t5003-archive-zip.sh    1   256    27   10  37.04%  9-11 17-19 21-23 25
1 subtest skipped.
Failed 1/1 test scripts, 0.00% okay. 10/27 subtests failed, 62.96% okay.
```

versus the new mingw-built unzip

``` sh
GIT_UNZIP="/mingw/bin/unzip" prove -v t5003-archive-zip.sh
1/27 skipped: add symlink (missing UNZIP_SYMLINKS,SYMLINKS of SYMLINKS,UNZIP_SYMLINKS)
All tests successful, 1 subtest skipped.
```
