### PR TITLE
Mingw32 package for GnuPG

### DIFF
--- a/root/packages/mingw32-gnupg.xml
+++ b/root/packages/mingw32-gnupg.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<software-distribution project="mingwGitDevEnv" home="https://github.com/sschuberth/mingwGitDevEnv" issue="2013041500">
+  <package-collection subsystem="mingw32">
+    <download-host
+      uri="https://dl.dropbox.com/u/6413030/mingwGitDevEnv/packages/mingw32-gnupg/%F" />
+
+    <package name="mingw32-gnupg">
+      <description lang="en" title="GnuPG is the GNU project's complete and free implementation of the OpenPGP standard as defined by RFC4880.">
+        <paragraph>GnuPG allows to encrypt and sign your data and communication, features a versatile key management system as well as access modules for all kinds of public key directories. GnuPG, also known as GPG, is a command line tool with features for easy integration with other applications. A wealth of frontend applications and libraries are available. Version 2 of GnuPG also provides support for S/MIME.
+        </paragraph>
+      </description>
+
+      <licence tarname="gnupg-%-mingw32-lic.tar.%" />
+      <source tarname="gnupg-%-mingw32-src.tar.%" />
+
+      <component class="bin">
+        <release tarname="gnupg-1.4.13-1-mingw32-bin.tar.lzma" />
+      </component>
+
+      <component class="doc">
+        <release tarname="gnupg-1.4.13-1-mingw32-doc.tar.lzma" />
+      </component>
+
+      <component class="lic">
+        <release tarname="gnupg-1.4.13-1-mingw32-lic.tar.lzma" />
+      </component>
+    </package>
+
+  </package-collection>
+</software-distribution>
+<!-- vim: set nocompatible expandtab fileformat=unix textwidth=80 tabstop=2 shiftwidth=2: -->

--- a/root/packages/mingw32-gnupg/gnupg-1.4.13-1.mgwport
+++ b/root/packages/mingw32-gnupg/gnupg-1.4.13-1.mgwport
@@ -1,0 +1,27 @@
+DESCRIPTION="GnuPG is the GNU project's complete and free implementation of the OpenPGP standard as defined by RFC4880."
+HOMEPAGE="http://www.gnupg.org"
+SRC_URI="http://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/${PN}-${PV}.tar.bz2
+         http://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/${PN}-${PV}.tar.bz2.sig"
+
+PKG_NAMES="${PN} ${PN} ${PN}"
+
+PKG_COMPTYPES="bin doc lic"
+
+PKG_CONTENTS[0]="bin"
+PKG_CONTENTS[1]="share/doc share/man share/info
+                 --exclude share/doc/${PN}/${PV}/COPYING"
+PKG_CONTENTS[2]="share/doc/${PN}/${PV}/COPYING"
+
+src_compile() {
+  cd ${B}
+  mgwconf
+  mgwmake
+}
+
+src_install() {
+  cd ${B}
+  mgwinstall
+  rm -rf ${D}/mingw/share/gnupg
+  mv -v ${D}/mingw/lib/gnupg/* ${D}/mingw/bin
+}
+

--- a/root/packages/mingwgitdevenv-package-list.xml
+++ b/root/packages/mingwgitdevenv-package-list.xml
@@ -5,6 +5,7 @@
 
   <package-list catalogue="mingw32-curl" />
   <package-list catalogue="mingw32-git" />
+  <package-list catalogue="mingw32-gnupg" />
   <package-list catalogue="mingw32-openssl" />
   <package-list catalogue="mingw32-tcl" />
   <package-list catalogue="mingw32-tk" />


### PR DESCRIPTION
An installed GnuPG will be picked up by mgwport and allows to check the signature
of a downloaded archive during package building.

This time I also added the xml cataloge file and updated mingwgitdevenv-package-list.xml. So hopefully the pull request is complete. If not don't hestitate to tell me.
