### PR TITLE
Add mingw32-libpcre as dependency

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -112,6 +112,7 @@ const
                         + 'mingw32-libexpat '
                         + 'mingw32-libiconv '
                         + 'mingw32-libopenssl '
+                        + 'mingw32-libpcre '
                         + 'mingw32-libz '
                         + 'mingw32-mgwport '
                         + 'mingw32-tk '


### PR DESCRIPTION
This enables us to compile git against libpcre.
And this makes thing like

```
git grep -P "\bpcre\b" HEAD
```

possible.
Which I already did in https://github.com/t-b/git/tree/use-libpcre. And all tests still pass with that too.
