### PR TITLE
Add a simple "nproc" implementation

### DIFF
--- a/root/local/bin/nproc
+++ b/root/local/bin/nproc
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -n "$NUMBER_OF_PROCESSORS" ]; then
+    echo $NUMBER_OF_PROCESSORS
+    exit
+fi
+
+wmic="$SYSTEMROOT/System32/wbem/wmic.exe"
+"$wmic" cpu get NumberOfLogicalProcessors 2> /dev/null | grep -oP "\d+" || echo 1


### PR DESCRIPTION
Our version of coreutils does not have "nproc" yet, so provide a simple
script-based implementation to allow "mgwport" to set MAKEOPTS to use an
appropriate number of make jobs.

Signed-off-by: Sebastian Schuberth sschuberth@gmail.com
