### PR TITLE
Add mingw32-openssl

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -137,6 +137,7 @@ const
                         + 'mingw32-gdb '
                         + 'mingw32-gnupg '
                         + 'mingw32-ntldd '
+                        + 'mingw32-openssl '
                         ;
 
 var


### PR DESCRIPTION
This is required to built the ca-bundle target of mingw32-curl.
